### PR TITLE
fixContainer slow on very large HTML documents

### DIFF
--- a/source/node/MergeSplit.ts
+++ b/source/node/MergeSplit.ts
@@ -59,18 +59,14 @@ const fixContainer = (
     container: Node,
     root: Element | DocumentFragment,
 ): Node => {
-    const children = container.childNodes;
     let wrapper: HTMLElement | null = null;
-    for (let i = 0, l = children.length; i < l; i += 1) {
-        const child = children[i];
+    [...container.childNodes].forEach(child => {
         const isBR = child.nodeName === 'BR';
         if (!isBR && isInline(child)) {
             if (!wrapper) {
                 wrapper = createElement('DIV');
             }
             wrapper.appendChild(child);
-            i -= 1;
-            l -= 1;
         } else if (isBR || wrapper) {
             if (!wrapper) {
                 wrapper = createElement('DIV');
@@ -80,15 +76,13 @@ const fixContainer = (
                 container.replaceChild(wrapper, child);
             } else {
                 container.insertBefore(wrapper, child);
-                i += 1;
-                l += 1;
             }
             wrapper = null;
         }
         if (isContainer(child)) {
             fixContainer(child, root);
         }
-    }
+    });
     if (wrapper) {
         container.appendChild(fixCursor(wrapper));
     }


### PR DESCRIPTION
fixContainer used a live NodeList and that made it very unresponsive on very large emails.

This PR solves the problem by converting the live list to a static array.

The fix uses the spread operator https://caniuse.com/?search=spread%20operator

More info at https://github.com/the-djmaze/snappymail/issues/962