### PR TITLE
Add `setConfig` function back into codebase

### DIFF
--- a/source/Editor.ts
+++ b/source/Editor.ts
@@ -257,6 +257,10 @@ class Squire {
         return this;
     }
 
+    setConfig(config: object): void {
+        this._config = this._makeConfig(config);
+    }
+
     _beforeInput(event: InputEvent): void {
         switch (event.inputType) {
             case 'insertText':


### PR DESCRIPTION
In version `2.0.0`, the `setConfig` function was removed from the codebase.
However, I believe that this function is important and should be included in the library.

This pull request adds the `setConfig` function back into the codebase.

Thank you for considering this pull request.