### PR TITLE
Avoid mangling the `-- ` signature delimiter

### DIFF
--- a/source/Clean.ts
+++ b/source/Clean.ts
@@ -283,7 +283,7 @@ const cleanTree = (
                     }
                     data = data.replace(/^[ \t\r\n]+/g, sibling ? ' ' : '');
                 }
-                if (endsWithWS) {
+                if (endsWithWS && data !== '-- ') {
                     walker.currentNode = child;
                     let sibling;
                     while ((sibling = walker.nextNode())) {

--- a/test/squire.spec.ts
+++ b/test/squire.spec.ts
@@ -521,6 +521,22 @@ describe('Squire RTE', () => {
             expect(link).toBe(null);
             editor.setHTML('');
         });
+        it('should truncate trailing whitespace', () => {
+            editor.insertHTML(
+            '<div>This is a line with a spurious space from <br></div><div>Arnout Engelen</div></div>'
+                );
+            const firstLine = document.querySelector('#squire div').textContent;
+            expect(firstLine).toBe('This is a line with a spurious space from');
+            editor.setHTML('');
+        });
+        it('should not mangle the signature delimiter', () => {
+            editor.insertHTML(
+            '<div>-- <br></div><div>Arnout Engelen</div></div>'
+                );
+            const firstLine = document.querySelector('#squire div').textContent;
+            expect(firstLine).toBe('-- ');
+            editor.setHTML('');
+        });
     });
 
     afterEach(() => {


### PR DESCRIPTION
As Squire is used for email clients a lot (I'm a happy Fastmail customer), and those might insert the signature into new emails with `setHTML`, it would be good if it would leave `-- ` [signature delimiter](https://en.wikipedia.org/wiki/Signature_block#Standard_delimiter) intact.

You could argue it's not very nice to 'special-case' the delimiter like this, though on the other hand it really *is* a special case and all other trailing whitespace does typically deserve to be truncated.

This problem is typically only encountered on Firefox, as when you add "-- " to the signature in Chromium it gets saved as "--&nbsp;" rather than "-- " so the whitespace removal code leaves it alone.