### PR TITLE
Add method to change block type

### DIFF
--- a/source/Editor.ts
+++ b/source/Editor.ts
@@ -2455,6 +2455,21 @@ class Squire {
         return frag;
     }
 
+    changeBlockType(
+        tag: string = this._config.blockTag,
+        attrs: Record<string, string> | null = this._config.blockAttributes
+    ) {
+        return this.modifyBlocks((frag) => {
+            const walker = getBlockWalker(frag, this._root);
+            const output = document.createDocumentFragment();
+            let node;
+            while ((node = walker.nextNode())) {
+                output.appendChild(createElement(tag, attrs, [empty(node)]));
+            }
+            return output;
+        });
+    };
+
     makeUnorderedList(): Squire {
         this.modifyBlocks((frag) => this._makeList(frag, 'UL'));
         return this.focus();


### PR DESCRIPTION
I found it very useful to use this function to set header tags (e.g. h1, h2, h3).
```js
this.editor.changeBlockType('h1');
this.editor.changeBlockType('h2');
this.editor.changeBlockType('h3');
```
To be clear, it's your @neilj example from this [PR](https://github.com/fastmail/Squire/issues/263#issuecomment-275825672).

If this type of method doesn't fit to the Squire's philosophy or plans right now, then could we expose couple "private" methods so we can build more upon the Squire (the best open-source editor out there imho) and not patch anything.